### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: sync github api
-        uses: google/secrets-sync-action@v1.4.1
+        uses: jpoehnelt/secrets-sync-action@v1.4.1
         with:
           SECRETS: |
             ^SYNCED_
@@ -30,7 +30,7 @@ jobs:
           SYNCED_GITHUB_TOKEN_REPO: ${{ secrets.GITHUBTOKEN_REPO }}
           
       - name: sync nuget key
-        uses: google/secrets-sync-action@v1.4.1
+        uses: jpoehnelt/secrets-sync-action@v1.4.1
         with:
           SECRETS: |
             ^SYNCED_
@@ -53,7 +53,7 @@ jobs:
           SYNCED_NUGET_KEY: ${{ secrets.NUGET_KEY }}
           
       - name: sync docker user/pass
-        uses: google/secrets-sync-action@v1.4.1
+        uses: jpoehnelt/secrets-sync-action@v1.4.1
         with:
           SECRETS: |
             ^SYNCED_
@@ -71,7 +71,7 @@ jobs:
           SYNCED_DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
           
       - name: sync powershell nuget
-        uses: google/secrets-sync-action@v1.4.1
+        uses: jpoehnelt/secrets-sync-action@v1.4.1
         with:
           SECRETS: |
             ^SYNCED_


### PR DESCRIPTION
This is a PR to update the action to the new repository location.\n\nNote GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.